### PR TITLE
feat: sync between devices

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ dist-xdc
 *.njsproj
 *.sln
 *.sw?
+.direnv

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,46 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1746904237,
+        "narHash": "sha256-3e+AVBczosP5dCLQmMoMEogM57gmZ2qrVSrmq9aResQ=",
+        "rev": "d89fc19e405cb2d55ce7cc114356846a0ee5e956",
+        "revCount": 797896,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.797896%2Brev-d89fc19e405cb2d55ce7cc114356846a0ee5e956/0196c1a7-7ad3-74a9-9d50-1b854aca6d6c/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/NixOS/nixpkgs/0.1"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1747017456,
+        "narHash": "sha256-C/U12fcO+HEF071b5mK65lt4XtAIZyJSSJAg9hdlvTk=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "5b07506ae89b025b14de91f697eba23b48654c52",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,58 @@
+{
+  description = "A Nix-flake-based Rust development environment";
+
+  inputs = {
+    nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0.1";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = inputs: let
+    supportedSystems = ["x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin"];
+    forEachSupportedSystem = f:
+      inputs.nixpkgs.lib.genAttrs supportedSystems (system:
+        f {
+          pkgs = import inputs.nixpkgs {
+            inherit system;
+            overlays = [
+              inputs.rust-overlay.overlays.default
+              inputs.self.overlays.default
+            ];
+          };
+        });
+  in {
+    overlays.default = final: prev: {
+      rustToolchain = let
+        rust = prev.rust-bin;
+      in
+        if builtins.pathExists ./rust-toolchain.toml
+        then rust.fromRustupToolchainFile ./rust-toolchain.toml
+        else if builtins.pathExists ./rust-toolchain
+        then rust.fromRustupToolchainFile ./rust-toolchain
+        else
+          rust.stable.latest.default.override {
+            extensions = ["rust-src" "rustfmt"];
+          };
+    };
+
+    devShells = forEachSupportedSystem ({pkgs}: {
+      default = pkgs.mkShell {
+        packages = with pkgs; [
+          rustToolchain
+          pkg-config
+          rust-analyzer
+          node2nix
+          nodejs
+          nodePackages.pnpm
+        ];
+
+        env = {
+          # Required by rust-analyzer
+          RUST_SRC_PATH = "${pkgs.rustToolchain}/lib/rustlib/src/rust/library";
+        };
+      };
+    });
+  };
+}

--- a/index.html
+++ b/index.html
@@ -1,16 +1,20 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/ironcalc.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <!-- <meta name="theme-color" content="#1bb566"> -->
-    <meta name="theme-color" media="(prefers-color-scheme: light)" content="#F2994A" />
-    <meta name="theme-color" media="(prefers-color-scheme: dark)" content="black" />
-    <title>IronCalc Spreadsheet</title>
-  </head>
-  <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
-  </body>
+
+<head>
+  <meta charset="UTF-8" />
+  <link rel="icon" type="image/svg+xml" href="/ironcalc.svg" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <!-- <meta name="theme-color" content="#1bb566"> -->
+  <meta name="theme-color" media="(prefers-color-scheme: light)" content="#F2994A" />
+  <meta name="theme-color" media="(prefers-color-scheme: dark)" content="black" />
+  <script src="./webxdc.js"></script>
+  <title>IronCalc Spreadsheet</title>
+</head>
+
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/main.tsx"></script>
+</body>
+
 </html>

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@emotion/styled": "^11.14.0",
     "@ironcalc/workbook": "0.3.2",
     "@mui/material": "^6.4",
+    "@webxdc/types": "^2.1.2",
     "@webxdc/vite-plugins": "^1.5.1",
     "lucide-react": "^0.473.0",
     "react": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@mui/material": "^6.4",
     "@webxdc/types": "^2.1.2",
     "@webxdc/vite-plugins": "^1.5.1",
+    "base64-arraybuffer": "^1.0.2",
     "lucide-react": "^0.473.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,15 @@ importers:
       '@mui/material':
         specifier: ^6.4
         version: 6.4.11(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@webxdc/types':
+        specifier: ^2.1.2
+        version: 2.1.2
       '@webxdc/vite-plugins':
         specifier: ^1.5.1
         version: 1.5.1(vite@6.2.6(terser@5.39.0))
+      base64-arraybuffer:
+        specifier: ^1.0.2
+        version: 1.0.2
       lucide-react:
         specifier: ^0.473.0
         version: 0.473.0(react@19.1.0)
@@ -1159,6 +1165,9 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0
 
+  '@webxdc/types@2.1.2':
+    resolution: {integrity: sha512-oklcyHvUXqCS5JwbPVaN8tt7nSB8ffRmyrUlVt0HeSn4kDyNE46oKSbw3KtrDzl530KHnm67LfcK/AjWbBoXUA==}
+
   '@webxdc/vite-plugins@1.5.1':
     resolution: {integrity: sha512-MQ+WalngoAVuiOFHiJo0q4XU+iv7AiIN/f52flOZjeI/rHWvGF0YvG8Pbu5ID5TpTsYOEqIlp9wgUa7+fbBmzQ==}
 
@@ -1188,6 +1197,10 @@ packages:
     resolution: {integrity: sha512-7gD3pRadPrbjhjLyxebmx/WrFYcuSjZ0XbdUujQMZ/fcE9oeewk2U/7PCvez84UeuK3oSjmPZ0Ch0dlupQvGzw==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
+
+  base64-arraybuffer@1.0.2:
+    resolution: {integrity: sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==}
+    engines: {node: '>= 0.6.0'}
 
   browserslist-to-esbuild@2.1.1:
     resolution: {integrity: sha512-KN+mty6C3e9AN8Z5dI1xeN15ExcRNeISoC3g7V0Kax/MMF9MSoYA2G7lkTTcVUFntiEjkpI0HNgqJC1NjdyNUw==}
@@ -2874,6 +2887,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@webxdc/types@2.1.2': {}
+
   '@webxdc/vite-plugins@1.5.1(vite@6.2.6(terser@5.39.0))':
     dependencies:
       '@vitejs/plugin-basic-ssl': 1.2.0(vite@6.2.6(terser@5.39.0))
@@ -2918,6 +2933,8 @@ snapshots:
       '@babel/helper-define-polyfill-provider': 0.6.4(@babel/core@7.26.10)
     transitivePeerDependencies:
       - supports-color
+
+  base64-arraybuffer@1.0.2: {}
 
   browserslist-to-esbuild@2.1.1(browserslist@4.24.4):
     dependencies:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,7 +24,7 @@ declare global {
 
 function App() {
   const [model, setModel] = useState<Model | null>(null);
-
+  const uuid = get_or_create_uuid();
   useEffect(() => {
     async function start() {
       await init();
@@ -76,8 +76,8 @@ function App() {
       }
       saveSelectedModelInStorage(model);
       const diffBase64 = base64Encode(diff);
-      console.log("Sending external diffs with lenght", diffBase64.length);
-      window.webxdc.sendUpdate({ payload: { data: diffBase64, sender: window.webxdc.selfAddr } }, "");
+      console.log("Sending external diffs with length", diffBase64.length);
+      window.webxdc.sendUpdate({ payload: { data: diffBase64, sender: uuid } }, "");
     }, 1000)
 
     window.webxdc.setUpdateListener((update) => {
@@ -88,7 +88,7 @@ function App() {
         console.warn("Received external diffs but model is not initialized yet");
         return
       }
-      if (payload.sender === window.webxdc.selfAddr) {
+      if (payload.sender === uuid) {
         return
       }
       // Decode base64 back to binary and convert to Uint8Array
@@ -148,14 +148,21 @@ const Loading = styled("div")`
 export default App;
 
 function get_last_serial(): number {
-  // get int number from localStorage with key "last_serial"
-  // and fill null value with 0 default
-
   const last_serial = localStorage.getItem("last_serial");
   if (last_serial === null) {
     localStorage.setItem("last_serial", "0");
     return 0;
   }
   return parseInt(last_serial, 10) || 0;
+}
+
+function get_or_create_uuid(): string {
+  const uuid = localStorage.getItem("uuid");
+  if (uuid) {
+    return uuid
+  }
+  const newUuid = crypto.randomUUID();
+  localStorage.setItem("uuid", newUuid);
+  return newUuid
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -65,10 +65,11 @@ function App() {
   let max_serial = get_last_serial()
 
   useEffect(() => {
+    if (!model) {
+      return
+    }
     const int = setInterval(() => {
-      if (!model) {
-        return
-      }
+
       let diff = model.flushSendQueue();
       if (diff.length <= 1) {
         return
@@ -102,7 +103,7 @@ function App() {
       clearInterval(int)
     }
   })
-  
+
 
   if (!model) {
     return (


### PR DESCRIPTION
The Ironcalc API provides a sync mechanism with `flushSendQueue` and `applyExternalDiffs`, which can be used to synchronize the state between multiple devices. This PR introduces a simple transport mechanism utilizing the `sendUpdate` webxdc API to transmit the update bit array and apply it to the other devices. 

In the future, it could be possible to extend this work to use the real-time API to get even more immediate changes. It is also still open for testing, where the ironcalc sync mechanism breaks - if it does. The current model is saved locally, so only new changes have to be applied every time the app is reopened. 

Here is a testing webxdc: 
[app.zip](https://github.com/user-attachments/files/20791728/app.zip)
Note, though, that the extension has to be renamed to `.xdc`